### PR TITLE
Fix import statement for useSwapyDraggable

### DIFF
--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -4,10 +4,10 @@ import { StoryModal } from './StoryModal';
 import { StoryCard } from './StoryCard';
 import { LogOut, Plus } from 'lucide-react';
 import {
-  SwapyProvider,
-  SwapyDroppable,
-  SwapyDraggable,
-} from 'swapy';
+  DndContext,
+  Droppable,
+  Draggable,
+} from '@dnd-kit/core';
 import toast from 'react-hot-toast';
 
 export function Dashboard() {
@@ -116,7 +116,7 @@ export function Dashboard() {
       </header>
 
       <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        <SwapyProvider
+        <DndContext
           onDragStart={handleDragStart}
           onDragEnd={handleDragEnd}
           onDragCancel={handleDragCancel}
@@ -131,13 +131,13 @@ export function Dashboard() {
                 <h2 className="text-lg font-semibold text-gray-900 mb-4">
                   {column.title}
                 </h2>
-                <SwapyDroppable
+                <Droppable
                   id={column.id}
                 >
                   {stories
                     .filter((story) => story.status === column.id)
                     .map((story) => (
-                      <SwapyDraggable
+                      <Draggable
                         key={story.id}
                         id={story.id}
                       >
@@ -147,13 +147,13 @@ export function Dashboard() {
                           onDelete={handleDelete}
                           style={getStoryStyle(story.id)}
                         />
-                      </SwapyDraggable>
+                      </Draggable>
                     ))}
-                </SwapyDroppable>
+                </Droppable>
               </div>
             ))}
           </div>
-        </SwapyProvider>
+        </DndContext>
       </main>
 
       <StoryModal

--- a/src/components/StoryCard.jsx
+++ b/src/components/StoryCard.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Edit2, Trash2 } from 'lucide-react';
-import { useSwapyDraggable } from 'swapy';
+import { useDraggable } from '@dnd-kit/core';
 
 export function StoryCard({ story, onEdit, onDelete, isDragging, style }) {
   const {
@@ -9,14 +9,14 @@ export function StoryCard({ story, onEdit, onDelete, isDragging, style }) {
     setNodeRef,
     transform,
     transition,
-    isDragging: isSwapyDragging,
-  } = useSwapyDraggable({ id: story.id });
+    isDragging: isDraggableDragging,
+  } = useDraggable({ id: story.id });
 
   const cardStyle = {
     transform: transform ? `translate3d(${transform.x}px, ${transform.y}px, 0)` : undefined,
     transition,
     ...style,
-    opacity: isSwapyDragging ? 0.5 : undefined,
+    opacity: isDraggableDragging ? 0.5 : undefined,
   };
 
   const handleEditClick = () => {


### PR DESCRIPTION
Update import statements and usage of draggable components in `StoryCard.jsx` and `Dashboard.jsx` to use `@dnd-kit/core` instead of `swapy`.

* **StoryCard.jsx**
  - Remove the import statement for `useSwapyDraggable` from `swapy`.
  - Add the correct import statement for `useDraggable` from `@dnd-kit/core`.
  - Update the usage of `useSwapyDraggable` to `useDraggable`.

* **Dashboard.jsx**
  - Remove the import statements for `SwapyProvider`, `SwapyDroppable`, and `SwapyDraggable` from `swapy`.
  - Add the correct import statements for `DndContext`, `Droppable`, and `Draggable` from `@dnd-kit/core`.
  - Update the usage of `SwapyProvider` to `DndContext`.
  - Update the usage of `SwapyDroppable` to `Droppable`.
  - Update the usage of `SwapyDraggable` to `Draggable`.

